### PR TITLE
Add common files to generated .gitignore

### DIFF
--- a/book-example/src/misc/contributors.md
+++ b/book-example/src/misc/contributors.md
@@ -11,3 +11,4 @@ If you have contributed to mdBook and I forgot to add you, don't hesitate to add
 - Wayne Nilsen ([waynenilsen](https://github.com/waynenilsen))
 - [funnkill](https://github.com/funkill)
 - Fu Gangqiang ([FuGangqiang](https://github.com/FuGangqiang))
+- Stefan Schindler ([dns2utf8](https://github.com/dns2utf8))

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -221,7 +221,14 @@ impl MDBook {
 
             debug!("[*]: Writing to .gitignore");
 
+            // Write the destination folder to file
             writeln!(f, "{}", relative).expect("Could not write to file.");
+            
+            // Add common files
+            let ignores = vec!("*~", ".DS_Store");
+            for pattern in ignores {
+                writeln!(f, "{}", pattern).expect("Could not write to file.");
+            }
         }
     }
 


### PR DESCRIPTION
I made a list inside the function because I think it is more maintainable than a long `&'static str`